### PR TITLE
Fix open Simulator command

### DIFF
--- a/src/simctl.rs
+++ b/src/simctl.rs
@@ -60,7 +60,11 @@ impl Simctl {
     /// (in case of multiple Xcode installations).
     pub fn open(&self) -> Result<()> {
         Command::new("open")
-            .arg(self.developer_dir.join("Simulator.app"))
+            .arg(
+                self.developer_dir
+                    .join("Applications")
+                    .join("Simulator.app"),
+            )
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .output()?


### PR DESCRIPTION
Does what it says in the title.

I'm not sure that Simulator in the Applications folder in every version of Xcode but on the latest one it's in.